### PR TITLE
FEAT: Sanitize inputs when scrap

### DIFF
--- a/src/main/instagram/index.ts
+++ b/src/main/instagram/index.ts
@@ -9,8 +9,6 @@ export async function makeScrappers(executablePath?: string) {
     args: ['--disk-cache-size=0', '--lang=en-US', '--no-sandbox'],
     defaultViewport: null,
     executablePath,
-    // TODO: delete after debugging
-    headless: false,
   });
 
   const instagramScrapper = new InsScarpperImpl(browser);

--- a/src/main/main.handler.ts
+++ b/src/main/main.handler.ts
@@ -105,4 +105,8 @@ export const bootstrap = async () => {
       `${err.name}: ${err.message}`
     );
   });
+
+  app.on('quit', () => {
+    instagramManager.close();
+  });
 };

--- a/src/main/naver/NaverManager.ts
+++ b/src/main/naver/NaverManager.ts
@@ -15,7 +15,14 @@ export class NaverManager {
     this.naverService = naverService;
   }
 
+  removeCRLFCase(string: string) {
+    return string.replace(/[\r\n]+/g, '');
+  }
+
   async scrap(keywords: Keyword[], urls: URL[], screenshotDirectory: string) {
+    const sanitizedKeywords = keywords.map(this.removeCRLFCase).filter(Boolean);
+    const sanitizedUrls = urls.map(this.removeCRLFCase).filter(Boolean);
+
     const currentTimeDirectory = path.join(
       screenshotDirectory,
       moment().format('YYYY-MM-DDTHH-mm-ss')
@@ -23,13 +30,13 @@ export class NaverManager {
 
     await mkdir(currentTimeDirectory, { recursive: true });
 
-    const scrapTasks = keywords.map((keyword, index) => {
+    const scrapTasks = sanitizedKeywords.map((keyword, index) => {
       return async (): Promise<ScrapResult> => {
         const page = await this.naverService.search(keyword);
 
         try {
           const findResults = await Promise.allSettled(
-            urls.map(async (url) => {
+            sanitizedUrls.map(async (url) => {
               const post = await this.naverService.findPosts(page, url);
               await this.naverService.makeRedBorder(post);
             })

--- a/src/main/naver/NaverManager.ts
+++ b/src/main/naver/NaverManager.ts
@@ -61,8 +61,7 @@ export class NaverManager {
             };
           }
         } finally {
-          // TODO: delete
-          // page.close();
+          page.close();
         }
       };
     });

--- a/src/main/naver/NaverManager.ts
+++ b/src/main/naver/NaverManager.ts
@@ -5,6 +5,7 @@ import moment from 'moment';
 import { Keyword, URL } from '../instagram/types';
 import { isFulfilled, isRejected } from '../instagram/util';
 import { ScrapResult } from 'main/@types/scrap';
+import { removeCRLFCase } from '../util';
 
 // TODO: NaverManager, ScrapperManager 하나로 합치기
 // 중복되는 로직 대다수, InsScrapper와 NaverService의 Interface만 통합한다면 가능
@@ -15,13 +16,9 @@ export class NaverManager {
     this.naverService = naverService;
   }
 
-  removeCRLFCase(string: string) {
-    return string.replace(/[\r\n]+/g, '');
-  }
-
   async scrap(keywords: Keyword[], urls: URL[], screenshotDirectory: string) {
-    const sanitizedKeywords = keywords.map(this.removeCRLFCase).filter(Boolean);
-    const sanitizedUrls = urls.map(this.removeCRLFCase).filter(Boolean);
+    const sanitizedKeywords = keywords.map(removeCRLFCase).filter(Boolean);
+    const sanitizedUrls = urls.map(removeCRLFCase).filter(Boolean);
 
     const currentTimeDirectory = path.join(
       screenshotDirectory,

--- a/src/main/naver/NaverServiceBase.ts
+++ b/src/main/naver/NaverServiceBase.ts
@@ -161,7 +161,6 @@ export abstract class NaverServiceBase implements NaverService {
       );
     }
 
-    console.log(boxModelOfPostList, boxModelOfTenthPost);
     const BOTTOM_RIGHT_CORNER = 2;
 
     await $searchPage.evaluate(() => {

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -58,3 +58,7 @@ export const handleWithCustomErrors = (
     }
   );
 };
+
+export function removeCRLFCase(string: string) {
+  return string.replace(/[\r\n]+/g, '');
+}


### PR DESCRIPTION
## What?
- Scrap시 입력값에 포함된 "\r"(Carriage Return) "\n"(Line Feed) 개행문자 제거

## Why?
- 윈도우 OS에서 스프레드시트에서 붙여넣기 할 시 'https://blog.naver.com/smy2166/223153253182\r', \r'와 같은식으로 개행문자가 입력값에 포함됨, 그에 따라서 CSS selector에서 unvalid selector 오류가 발생해서 정상적으로 포스트를 찾지 못하는 상황 발생, 이를 해결하기 위해 개행문자 제거 로직 추가

## How?
- Manager 단에서 인자로 받은 값에서 개행문자를 제거 후 검색 및 탐색 로직 실행

## Anything Else?
