### PR TITLE
FIX: Handling Updates to Naver UI and Query Parameters

### DIFF
--- a/src/main/naver/NaverFactory.ts
+++ b/src/main/naver/NaverFactory.ts
@@ -5,21 +5,21 @@ import { NaverViewService } from './NaverViewService';
 export class NaverFactory {
   static createCafeService(browser: Browser) {
     const NAVER_CAFE_VIEW_URL =
-      'https://search.naver.com/search.naver?where=article';
+      'https://search.naver.com/search.naver?ssc=tab.cafe.all';
 
     return new NaverViewService(browser, NAVER_CAFE_VIEW_URL);
   }
 
   static createBlogService(browser: Browser) {
     const NAVER_BLOG_VIEW_URL =
-      'https://search.naver.com/search.naver?where=blog';
+      'https://search.naver.com/search.naver?ssc=tab.blog.all';
 
     return new NaverViewService(browser, NAVER_BLOG_VIEW_URL);
   }
 
   static createInfluencer(browser: Browser) {
     const NAVER_INFLUENCER_URL =
-      'https://search.naver.com/search.naver?where=influencer';
+      'https://search.naver.com/search.naver?ssc=tab.influencer.chl&where=influencer';
 
     return new InfluencerService(browser, NAVER_INFLUENCER_URL);
   }

--- a/src/main/naver/NaverInfluencerService.ts
+++ b/src/main/naver/NaverInfluencerService.ts
@@ -25,7 +25,7 @@ export class InfluencerService extends NaverServiceBase {
     const postID = this.extractBlogPostIDFromPostURL(postURL);
 
     const $post = await $postList.$(
-      `:scope > li:has(a[data-foryou-gdid*="${postID}"]):not(.type_join)`
+      `:scope > li:has(div.title_area > a[data-foryou-gdid*="${postID}"]):not(.type_join)`
     );
 
     return $post ? $post.toElement('li') : null;

--- a/src/main/naver/NaverServiceBase.ts
+++ b/src/main/naver/NaverServiceBase.ts
@@ -33,7 +33,7 @@ export abstract class NaverServiceBase implements NaverService {
 
   async waitUntilImageLoaded($postList: ElementHandle<HTMLUListElement>) {
     return $postList.evaluate(async ($postListElement) => {
-      const images = $postListElement.querySelectorAll(
+      const images = $postListElement.querySelectorAll<HTMLImageElement>(
         'li:nth-child(-n + 10) .detail_box img'
       );
 
@@ -137,10 +137,13 @@ export abstract class NaverServiceBase implements NaverService {
   }
 
   private async makeBorderForCategory($searchPage: Page) {
-    const categoryQuery = new URL($searchPage.url()).searchParams.get('where');
+    const QUERY_PARAMETER_NAME = 'ssc';
+    const categoryQuery = new URL($searchPage.url()).searchParams.get(
+      QUERY_PARAMETER_NAME
+    );
 
     const $categoryBox = await $searchPage.$(
-      `a[href*="where=${categoryQuery}"]`
+      `a[href*="${QUERY_PARAMETER_NAME}=${categoryQuery}"]`
     );
 
     if (!$categoryBox) {


### PR DESCRIPTION
## What?
- 네이버 UI 및 검색창별 Query Parameter가 변경됨에 따라 대응 업데이트 진행
- Influncer 검색 결과에서 포스트별 연관 게시물을 보여주도록 UI가 변경됨, 이에 따라 대응 업데이트 진행

## Why?
- 기존의 네이버 검색창은 "where" parameter에 따라서 인플루언서, 블로그, 카페 검색을 구분했었음 그런데 업데이트로 인해 UI가 변경되고 query parameter가 "where"에서 "ssc"로 변경되었기에 거기에 맞춰서 대응
- InflucerService의 기존 셀렉터는 연관 게시물까지 함께 포함해서 검색하기에 메인 포스트가 포함되지 않더라도 연관 게시물에 top 10 포스트가 있다면 포함한다고 잘못된 검색 결과를 도출함.

## How?
- Naver Factory에서 인자로 주입하는 baseURL의 query parameter 변경
- InflucerService에서 findPost에서 사용하는 selector 변경, 기존 셀렉터는 연관 게시물까지 함께 포함해서 검색하기에 메인 포스트가 포함되지 않더라도 연관 게시물에 top 10 포스트가 있다면 포함한다고 잘못된 검색 결과를 도출함. 따라서, 셀렉터의 범위를 포스트 제목 부분으로 축소함

## Anything Else?
